### PR TITLE
Revise installation instruction

### DIFF
--- a/HD_BET/paths.py
+++ b/HD_BET/paths.py
@@ -1,4 +1,4 @@
-import os
+from os.path import dirname, abspath, join as pjoin
 
 # please refer to the readme on where to get the parameters. Save them in this folder:
-folder_with_parameter_files = os.path.join(os.path.expanduser('~'), 'hd-bet_params')
+folder_with_parameter_files = pjoin(dirname(abspath(__file__)),'params')

--- a/HD_BET/run.py
+++ b/HD_BET/run.py
@@ -72,7 +72,7 @@ def run_hd_bet(mri_fnames, output_fnames, mode="accurate", config_file=os.path.j
 
     params = []
     for p in list_of_param_files:
-        params.append(torch.load(p, map_location=lambda storage, loc: storage))
+        params.append(torch.load(p, map_location=lambda storage, loc: storage, weights_only=True))
 
     for in_fname, out_fname in zip(mri_fnames, output_fnames):
         mask_fname = out_fname[:-7] + "_mask.nii.gz"

--- a/readme.md
+++ b/readme.md
@@ -33,14 +33,14 @@ all modern GPUs: RTX 4080, RTX 4090, RTX A6000, A100, and GTX 1080. This redefin
 at Psychiatry Neuroimaging Laboratory, Brigham and Women's Hospital, Boston, Massachusetts. The steps are:
 
 ```
-conda create -y -n hd-bet python=3.6
+conda create -y -n hd-bet python=3.9 -c conda-forge --override-channel
 conda activate hd-bet
 
 git clone --single-branch --branch pnl git@github.com:pnlbwh/HD-BET.git
 cd HD-BET/
 pip install .
 
-conda install pytorch torchvision pytorch-cuda=12.1 -c pytorch -c nvidia
+pip3 install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cu121
 ```
 
 The last `pytorch-cuda=12.1` makes it possible to run `hd-bet` on our GPUs that are CUDA `v12.*` compatible.

--- a/readme.md
+++ b/readme.md
@@ -33,7 +33,7 @@ all modern GPUs: RTX 4080, RTX 4090, RTX A6000, A100, and GTX 1080. This redefin
 at Psychiatry Neuroimaging Laboratory, Brigham and Women's Hospital, Boston, Massachusetts. The steps are:
 
 ```
-conda create -y -n hd-bet python=3.9 -c conda-forge --override-channel
+conda create -y -n hd-bet python=3.9 -c conda-forge --override-channels
 conda activate hd-bet
 
 git clone --single-branch --branch pnl git@github.com:pnlbwh/HD-BET.git
@@ -43,20 +43,14 @@ pip install .
 pip3 install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cu121
 ```
 
-The last `pytorch-cuda=12.1` makes it possible to run `hd-bet` on our GPUs that are CUDA `v12.*` compatible.
-Both channels `-c pytorch -c nvidia` are necessary to install dependencies of `pytorch-cuda=12.1`
+PyTorch installation is inspired by https://pytorch.org/get-started/locally/.
+
 
 After completing installation, you can invoke `hd-bet` by absolute path without sourcing or activating any environment:
 
 > /path/to/miniconda3/envs/hd-bet/bin/hd-bet --help
 
-<details><summary>References</summary>
- 
-* https://anaconda.org/pytorch/pytorch-cuda/files
-* https://www.reddit.com/r/pytorch/comments/11z9vkf/pytorch_installation_with_cuda_121/
-* https://pytorch.org/get-started/locally/
 
-</details>
 
 ## How to use it 
 

--- a/readme.md
+++ b/readme.md
@@ -26,30 +26,37 @@ coefficient and -0.80 to -2.75 mm for the Hausdorff distance (Bonferroni-adjuste
 - HD-BET is very fast on GPU with <10s run time per MRI sequence. Even on CPU it is not slower than other commonly 
 used tools.
 
-## Installation Instructions 
-Note that you need to have a python3 installation for HD-BET to work. Please also make sure to install HD-BET with the
-correct pip version (the one that is connected to python3). You can verify this using the `--version` command:
+## Installation Instructions
+
+Psychiatry Neuroimaging Laboratory has redefined the installation scheme for this program to work on
+all modern GPUs: RTX 4080, RTX 4090, RTX A6000, A100, and GTX 1080. This redefinition came out of days of research
+at Psychiatry Neuroimaging Laboratory, Brigham and Women's Hospital, Boston, Massachusetts. The steps are:
 
 ```
-(dl_venv) fabian@Fabian:~$ pip --version
-pip 20.0.2 from /home/fabian/dl_venv/lib/python3.6/site-packages/pip (python 3.6)
+conda create -y -n hd-bet python=3.6
+conda activate hd-bet
+
+git clone --single-branch --branch pnl git@github.com:pnlbwh/HD-BET.git
+cd HD-BET/
+pip install .
+
+conda install pytorch torchvision pytorch-cuda=12.1 -c pytorch -c nvidia
 ```
 
-If it does not show python 3.X, you can try pip3. If that also does not work you probably need to install python3 first.
+The last `pytorch-cuda=12.1` makes it possible to run `hd-bet` on our GPUs that are CUDA `v12.*` compatible.
+Both channels `-c pytorch -c nvidia` are necessary to install dependencies of `pytorch-cuda=12.1`
 
-Once python 3 and pip are set up correctly, run the following commands to install HD-BET:
-1) Clone this repository:
-    ```bash
-    git clone https://github.com/MIC-DKFZ/HD-BET
-    ```
-2) Go into the repository (the folder with the setup.py file) and install:
-    ```
-    cd HD-BET
-    pip install -e .
-    ```
-3) Per default, model parameters will be downloaded to ~/hd-bet_params. If you wish to use a different folder, open 
-HD_BET/paths.py in a text editor and modify ```folder_with_parameter_files```
+After completing installation, you can invoke `hd-bet` by absolute path without sourcing or activating any environment:
 
+> /path/to/miniconda3/envs/hd-bet/bin/hd-bet --help
+
+<details><summary>References</summary>
+ 
+* https://anaconda.org/pytorch/pytorch-cuda/files
+* https://www.reddit.com/r/pytorch/comments/11z9vkf/pytorch_installation_with_cuda_121/
+* https://pytorch.org/get-started/locally/
+
+</details>
 
 ## How to use it 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 numpy>=1.14.5
-torch>=0.4.0
 scikit-image>=0.14.0
 SimpleITK==2.0.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
-numpy>=1.14.5
 scikit-image>=0.14.0
 SimpleITK==2.0.2


### PR DESCRIPTION
* This revision is primarily motivated by omission of anaconda channel
* Install PyTorch according to official instruction
* Omit repeat install of torch and numpy
* See commit messages